### PR TITLE
Remove `/tasks/{chainTaskId}` endpoint, the adapter must only call `i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [[NEXT]](https://github.com/iExecBlockchainComputing/iexec-blockchain-adapter-api/releases/tag/vNEXT) 2024
 
+### Bug Fixes
+
+- Remove `/tasks/{chainTaskId}` endpoint, the adapter must only call `initialize` and `finalize` **PoCo** methods. (#130)
+
 ## [[8.3.0]](https://github.com/iExecBlockchainComputing/iexec-blockchain-adapter-api/releases/tag/v8.3.0) 2024-01-10
 
 ### New Features

--- a/iexec-blockchain-adapter-api-library/src/main/java/com/iexec/blockchain/api/BlockchainAdapterApiClient.java
+++ b/iexec-blockchain-adapter-api-library/src/main/java/com/iexec/blockchain/api/BlockchainAdapterApiClient.java
@@ -19,7 +19,6 @@ package com.iexec.blockchain.api;
 import com.iexec.common.chain.adapter.args.TaskFinalizeArgs;
 import com.iexec.common.config.PublicChainConfig;
 import com.iexec.common.sdk.broker.BrokerOrder;
-import com.iexec.commons.poco.chain.ChainTask;
 import feign.Param;
 import feign.RequestLine;
 
@@ -40,9 +39,6 @@ public interface BlockchainAdapterApiClient {
 
     @RequestLine("GET /metrics")
     String getMetrics();
-
-    @RequestLine("GET /tasks/{chainTaskId}")
-    ChainTask getTask(@Param("chainTaskId") String chainTaskId);
 
     @RequestLine("POST /tasks/initialize?chainDealId={chainDealId}&taskIndex={taskIndex}")
     String requestInitializeTask(@Param("chainDealId") String chainDealId,

--- a/src/main/java/com/iexec/blockchain/command/task/TaskController.java
+++ b/src/main/java/com/iexec/blockchain/command/task/TaskController.java
@@ -21,7 +21,6 @@ import com.iexec.blockchain.command.task.finalize.TaskFinalizeService;
 import com.iexec.blockchain.command.task.initialize.TaskInitializeService;
 import com.iexec.blockchain.tool.IexecHubService;
 import com.iexec.common.chain.adapter.args.TaskFinalizeArgs;
-import com.iexec.commons.poco.chain.ChainTask;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
@@ -43,21 +42,6 @@ public class TaskController {
         this.iexecHubService = iexecHubService;
         this.taskInitializeService = taskInitializeService;
         this.taskFinalizeService = taskFinalizeService;
-    }
-
-    /**
-     * Read task metadata on the blockchain.
-     *
-     * @param chainTaskId blockchain ID of the task
-     * @return task metadata
-     */
-    @Operation(security = @SecurityRequirement(name = SWAGGER_BASIC_AUTH))
-    @GetMapping("/{chainTaskId}")
-    public ResponseEntity<ChainTask> getTask(
-            @PathVariable String chainTaskId) {
-        return iexecHubService.getChainTask(chainTaskId)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
     }
 
     /**


### PR DESCRIPTION
…nitialize` and `finalize` **PoCo** methods